### PR TITLE
Add idle-less to Other tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ by James Forshaw.
 * [Nmap](https://nmap.org/) - A free and open source software for network discovery and security auditing.
 * [Zenmap](https://nmap.org/zenmap/) - The official Nmap Security Scanner GUI.
 * [Draw.io](https://github.com/jgraph/drawio-desktop) - An open source software for creating network diagrams and topologies.
+* [idle-less](https://github.com/tvup/idle-less) - A Docker-based nginx reverse proxy that wakes sleeping servers via Wake-on-LAN (WoL), enabling energy-efficient homelab setups by letting machines power down when idle.
 
 ## Certifications
 


### PR DESCRIPTION
Adding **idle-less** to the Other tools section.

idle-less is a Docker-based nginx reverse proxy with integrated Wake-on-LAN (WoL) support. When traffic arrives for a domain whose backend server is powered off, it sends a WoL magic packet to wake the machine, displays a waiting page, and redirects the user once the server is online.

- **GitHub:** https://github.com/tvup/idle-less
- **License:** MIT
- **Use case:** Energy-efficient networking for homelabs and self-hosted infrastructure

A unique tool that bridges reverse proxying with network-level power management via Wake-on-LAN.