### PR TITLE
Add ftagent-lite - lightweight open-source DDoS traffic monitor for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ by James Forshaw.
 * [SecureCRT](https://www.vandyke.com/products/securecrt/) - A commercial SSH and Telnet client and terminal emulator by VanDyke Software.
 * [WinBox](https://mikrotik.com/download) - Official MikroTik GUI software for administration of MikroTik RouterOS.
 
+### DDoS Detection and Mitigation
+
+* [ftagent-lite](https://github.com/Flowtriq/ftagent-lite) - Lightweight open-source DDoS traffic monitor for Linux. Per-packet inspection, detects attack types in real time. MIT license.
+
 ### Other tools
 
 * [Nmap](https://nmap.org/) - A free and open source software for network discovery and security auditing.


### PR DESCRIPTION
ftagent-lite is a lightweight open-source DDoS traffic monitor for Linux servers. Per-packet inspection, detects attack types in real time. MIT licensed.

Repo: https://github.com/Flowtriq/ftagent-lite

Adding as a new DDoS Detection and Mitigation subsection under Software and Tools.