### PR TITLE
Add Packet Test Bundle to Other tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ by James Forshaw.
 * [Zenmap](https://nmap.org/zenmap/) - The official Nmap Security Scanner GUI.
 * [Draw.io](https://github.com/jgraph/drawio-desktop) - An open source software for creating network diagrams and topologies.
 * [idle-less](https://github.com/tvup/idle-less) - A Docker-based nginx reverse proxy that wakes sleeping servers via Wake-on-LAN (WoL), enabling energy-efficient homelab setups by letting machines power down when idle.
+* [Packet Test Bundle](https://github.com/galenthas/packet-test-bundle) - A native Windows GUI bundling iperf2, iperf3, tshark, and ping for network bandwidth and latency testing with live charts.
 
 ## Certifications
 


### PR DESCRIPTION
Adds [Packet Test Bundle](https://github.com/galenthas/packet-test-bundle) — a free, open-source native Windows GUI that bundles iperf2, iperf3, tshark, and ping into a single application for network bandwidth testing, latency monitoring, and packet capture with live charts.

It fits the **Other tools** section as a network diagnostic tool that combines multiple CLI utilities (iperf2, iperf3, tshark, ping) under one GUI.

- MIT licensed
- Actively maintained
- Windows 10/11