### PR TITLE
Add Open-IPv8-Lab to Network simulators and emulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ by James Forshaw.
 * [Cisco Modeling Labs](https://www.cisco.com/c/en/us/products/cloud-systems-management/modeling-labs/index.html) - An online platform that helps network engineers simulate the behavior of Cisco routers, switches, and access points. It is intended for customers from enterprise backgrounds.
 * [Cisco Virtual Internet Routing Lab (VIRL)](https://learningnetwork.cisco.com/s/virl) - It is a Cisco IOS-based comprehensive network simulation environment. It is intended for all individuals and trainees.
 * [ContainerLab](https://containerlab.dev/) - A tool to build network topologies using containers.
+* [Open-IPv8-Lab](https://github.com/LF3551/Open-IPv8-Lab) - An experimental userspace IPv8 toolkit implementing draft-thain-ipv8-02 with CLI, routing simulation, and packet analysis.
 
 ### Firewalls and switches
 


### PR DESCRIPTION
## Description

Adding [Open-IPv8-Lab](https://github.com/LF3551/Open-IPv8-Lab) — an experimental userspace IPv8 toolkit implementing [draft-thain-ipv8-02](https://datatracker.ietf.org/doc/draft-thain-ipv8-02/) with CLI, routing simulation, and packet analysis.

- **Language:** Python
- **License:** BSD-3-Clause
- **Tests:** 1827 tests
- **Available on:** [PyPI](https://pypi.org/project/open-ipv8-lab/), [Docker Hub](https://hub.docker.com/r/lf3551/open-ipv8-lab), [Read the Docs](https://open-ipv8-lab.readthedocs.io)
- **DOI:** [10.5281/zenodo.20201237](https://doi.org/10.5281/zenodo.20201237)

Added to the **Network simulators and emulators** section as it provides routing simulation and protocol-level packet handling in userspace.

Following the contribution guidelines:
- Format: `* [name](url) - A short description ends with a period.`
- Placed at the end of the section
- No duplicate entries