### PR TITLE
Add NodalArc to Network simulators and emulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ by James Forshaw.
 * [Cisco Virtual Internet Routing Lab (VIRL)](https://learningnetwork.cisco.com/s/virl) - It is a Cisco IOS-based comprehensive network simulation environment. It is intended for all individuals and trainees.
 * [ContainerLab](https://containerlab.dev/) - A tool to build network topologies using containers.
 * [Open-IPv8-Lab](https://github.com/LF3551/Open-IPv8-Lab) - An experimental userspace IPv8 toolkit implementing draft-thain-ipv8-02 with CLI, routing simulation, and packet analysis.
+* [NodalArc](https://github.com/dotchance/nodalarc) - An open-source satellite network emulator that runs real Linux routing stacks (FRR with IS-IS, OSPF, BGP, and MPLS) on top of moving LEO topology. Satellites are Linux network namespaces; orbital motion drives carrier transitions, link latency, and ground-station handoffs.
 
 ### Firewalls and switches
 


### PR DESCRIPTION
Adds NodalArc to the Network simulators and emulators section.

NodalArc is an open-source satellite network emulator. It runs FRR with real IS-IS, OSPF, BGP, and MPLS adjacencies on top of a moving LEO constellation. Each satellite is a Linux network namespace; links go up and down based on orbital geometry; ground-station handoffs propagate through the routing stack as carrier events. Same family as GNS3, EVE-NG, and ContainerLab in that it uses real routing software, but oriented around moving satellite topology rather than static enterprise or data-center labs.

Repository: https://github.com/dotchance/nodalarc