### PR TITLE
Add Dalil Tech Subnet Calculator to Online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ by James Forshaw.
 * [What Is My IP](https://whatismyip.help/) - A tool for quickly checking your public IPv4 and IPv6 addresses on desktop and mobile, built with privacy and usability in mind.
 * [IPv6 / IPv4 Connectivity Test](https://test-ipv6.run/) - A browser-based tool to test IPv4/IPv6 connectivity, measure protocol latency, check dual-stack readiness, and score your network's IPv6 deployment.
 * [NetworkWhois](https://networkwhois.com/) - Free online network diagnostic tools (IP WHOIS, DNS records lookup, DNS propagation, reverse DNS, blacklist checks, SSL checker, website status, and more).
+* [Dalil Tech Subnet Calculator](https://dalil-tech.com/subnet-calculator) - IPv4 and IPv6 subnet and CIDR calculator with VLSM, a binary network/host view, overlap and summarization, in the browser with no signup.
 
 ### Packet capture and analysis
 


### PR DESCRIPTION
Adds a free, browser-based IPv4 and IPv6 subnet and CIDR calculator to the Online tools section.

It covers the network, broadcast, mask, wildcard, and host-range basics, plus a VLSM planner, a binary network-vs-host view, a CIDR overlap check, summarization into a single block, and IPv6 subnet splitting. No signup, no ads, runs entirely in the browser.

The Online tools section has several single-purpose lookups (nslookup, whois, what-is-my-ip) but no subnet calculator, so this fills the gap. I built and maintain it.