### PR TITLE
Add MoonProxy - Desktop GUI client for FRP

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ by James Forshaw.
 * [idle-less](https://github.com/tvup/idle-less) - A Docker-based nginx reverse proxy that wakes sleeping servers via Wake-on-LAN (WoL), enabling energy-efficient homelab setups by letting machines power down when idle.
 * [Packet Test Bundle](https://github.com/galenthas/packet-test-bundle) - A native Windows GUI bundling iperf2, iperf3, tshark, and ping for network bandwidth and latency testing with live charts.
 
+* [MoonProxy](https://github.com/MoonProxyHQ/moonproxy-desktop) - A cross-platform desktop GUI client for FRP (Fast Reverse Proxy), built with Tauri v2, Vue 3, and Rust. Available for macOS and Windows.
+
 ## Certifications
 
 * [Cisco certifications](https://www.cisco.com/c/en/us/training-events/training-certifications/certifications.html)


### PR DESCRIPTION
## What
Adds [MoonProxy](https://github.com/MoonProxyHQ/moonproxy-desktop) to the **Other tools** section under Software and Tools.

## Why
MoonProxy is an open-source (MIT) cross-platform desktop GUI client for FRP (Fast Reverse Proxy), built with Tauri v2, Vue 3, and Rust. It provides a user-friendly graphical interface for managing FRP configurations on macOS and Windows, complementing the existing command-line and web-based networking tools already listed. FRP itself is widely used for NAT traversal and reverse proxying, and a dedicated native desktop client fills a gap in the list.

## Checklist
- [x] Entry follows the existing `* [name](url) - Description.` format
- [x] Placed at the end of the relevant category (Other tools), per CONTRIBUTING.md
- [x] Description is accurate and concise, ends with a period
- [x] Not a duplicate (searched existing entries)
- [x] Links to the official open-source repository
