### PR TITLE
Add NetTools to Online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ by James Forshaw.
 * [What Is My IP](https://whatismyip.help/) - A tool for quickly checking your public IPv4 and IPv6 addresses on desktop and mobile, built with privacy and usability in mind.
 * [IPv6 / IPv4 Connectivity Test](https://test-ipv6.run/) - A browser-based tool to test IPv4/IPv6 connectivity, measure protocol latency, check dual-stack readiness, and score your network's IPv6 deployment.
 * [NetworkWhois](https://networkwhois.com/) - Free online network diagnostic tools (IP WHOIS, DNS records lookup, DNS propagation, reverse DNS, blacklist checks, SSL checker, website status, and more).
+* [NetTools](https://beomanro.com/) - Free browser-based network tools (subnet calculator, CIDR to range, MAC OUI lookup, MTU/MSS calculator, and more) with practical guides.
 
 ### Packet capture and analysis
 


### PR DESCRIPTION
Adds [NetTools](https://beomanro.com/) to the Online tools section.

Free browser-based network tools for network engineers: subnet calculator, CIDR to range, MAC OUI lookup, MTU/MSS calculator, DNS record guides, and more. All tools run client-side, no signup, ko/en. Follows the existing multi-tool site precedent (MXToolbox, NetworkWhois).

Checked for duplicates — not present in the list. Entry added at the end of the section per CONTRIBUTING guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)