### PR TITLE
Add Obelinf Toolkit to the Online tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ by James Forshaw.
 * [What Is My IP](https://whatismyip.help/) - A tool for quickly checking your public IPv4 and IPv6 addresses on desktop and mobile, built with privacy and usability in mind.
 * [IPv6 / IPv4 Connectivity Test](https://test-ipv6.run/) - A browser-based tool to test IPv4/IPv6 connectivity, measure protocol latency, check dual-stack readiness, and score your network's IPv6 deployment.
 * [NetworkWhois](https://networkwhois.com/) - Free online network diagnostic tools (IP WHOIS, DNS records lookup, DNS propagation, reverse DNS, blacklist checks, SSL checker, website status, and more).
+* [Obelinf Toolkit](https://obelinf.com/toolkit/) - Free online network tools for IP and subnet planning, VLAN management, device naming conventions, checklists, and reference tables.
 
 ### Packet capture and analysis
 


### PR DESCRIPTION
Adds the [Obelinf Toolkit](https://obelinf.com/toolkit/) to the **Online tools** section under Software and Tools.

The toolkit is a free collection of browser-based network tools: IP and subnet calculators, VLAN planning aids, device naming conventions, checklists, and reference tables.