### PR TITLE
Add Aurora to network simulators and emulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ by James Forshaw.
 * [ContainerLab](https://containerlab.dev/) - A tool to build network topologies using containers.
 * [Open-IPv8-Lab](https://github.com/LF3551/Open-IPv8-Lab) - An experimental userspace IPv8 toolkit implementing draft-thain-ipv8-02 with CLI, routing simulation, and packet analysis.
 * [NodalArc](https://github.com/dotchance/nodalarc) - An open-source satellite network emulator that runs real Linux routing stacks (FRR with IS-IS, OSPF, BGP, and MPLS) on top of moving LEO topology. Satellites are Linux network namespaces; orbital motion drives carrier transitions, link latency, and ground-station handoffs.
-* [Aurora](https://github.com/Daniele-Cangi/Aurora) - A C++20 systems-research engine for deterministic heterogeneous-network simulation and authenticated process-separated UDP transport emulation, with runtime-selectable fixed and bio-inspired adaptive protection policies.
+* [Aurora](https://github.com/Daniele-Cangi/Aurora) - A C++20 network research testbed for deterministic heterogeneous-network simulation and authenticated process-separated UDP transport emulation, with reproducible testing of fixed and bio-inspired adaptive protection policies.
 
 ### Firewalls and switches
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ by James Forshaw.
 * [ContainerLab](https://containerlab.dev/) - A tool to build network topologies using containers.
 * [Open-IPv8-Lab](https://github.com/LF3551/Open-IPv8-Lab) - An experimental userspace IPv8 toolkit implementing draft-thain-ipv8-02 with CLI, routing simulation, and packet analysis.
 * [NodalArc](https://github.com/dotchance/nodalarc) - An open-source satellite network emulator that runs real Linux routing stacks (FRR with IS-IS, OSPF, BGP, and MPLS) on top of moving LEO topology. Satellites are Linux network namespaces; orbital motion drives carrier transitions, link latency, and ground-station handoffs.
+* [Aurora](https://github.com/Daniele-Cangi/Aurora) - A C++20 systems-research engine for deterministic heterogeneous-network simulation and authenticated process-separated UDP transport emulation, with runtime-selectable fixed and bio-inspired adaptive protection policies.
 
 ### Firewalls and switches
 


### PR DESCRIPTION
## Summary

- Add Aurora to the **Network simulators and emulators** section.
- Link to the official Aurora repository and describe its implemented simulation, process-separated UDP emulation, and runtime-selectable transport policies.

## Why

Aurora is a C++20 systems-research engine for resilient heterogeneous networks. It includes deterministic network simulation and authenticated process-separated UDP transport emulation, making this the closest existing category in the list.

## Validation

- The entry follows the documented `* [name](url) - Description.` format.
- It is appended to the end of the appropriate category as requested by the contribution guidelines.
- No existing Aurora entry or pull request was found.
- `git diff --check` passes.

This is a documentation-only change.
