### PR TITLE
Add Zero Dollar Domains to Online tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ by James Forshaw.
 * [What Is My IP](https://whatismyip.help/) - A tool for quickly checking your public IPv4 and IPv6 addresses on desktop and mobile, built with privacy and usability in mind.
 * [IPv6 / IPv4 Connectivity Test](https://test-ipv6.run/) - A browser-based tool to test IPv4/IPv6 connectivity, measure protocol latency, check dual-stack readiness, and score your network's IPv6 deployment.
 * [NetworkWhois](https://networkwhois.com/) - Free online network diagnostic tools (IP WHOIS, DNS records lookup, DNS propagation, reverse DNS, blacklist checks, SSL checker, website status, and more).
+* [Zero Dollar Domains](https://arynjennen1989-stack.github.io/) - Live RDAP hunter for unused cheap TLD names plus a catalog of still-free domain programs.
 
 ### Packet capture and analysis
 


### PR DESCRIPTION
Adds [Zero Dollar Domains](https://arynjennen1989-stack.github.io/) at the end of Software and Tools > Online tools.

It is a live RDAP hunter for unused cheap TLD names plus a catalog of programs that still give a $0 domain or subdomain (eu.org, is-a.dev). Not an expired-.com dump.

Public URL to verify: https://arynjennen1989-stack.github.io/