### PR TITLE
Add Tracexy to Packet capture and analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ by James Forshaw.
 * [Malware-Traffic-Analysis.net](https://malware-traffic-analysis.net/) - A large collection of malicious PCAP files that can be used to practice packet capture skills.
 * [Publicly Available PCAP files](https://www.netresec.com/?page=PcapFiles) - A list of publicly available PCAP files for additional training.
 * [PWRU (Packet, where are you?)](https://github.com/cilium/pwru) - eBPF-based Linux kernel networking debugger.
+* [Tracexy](https://github.com/RockxyApp/Tracexy) - A native, local-first macOS app for capturing live traffic and investigating PCAP and PCAPNG files.
 
 ### Network simulators and emulators
 


### PR DESCRIPTION
Adds [Tracexy](https://github.com/RockxyApp/Tracexy), a native, local-first macOS app for capturing live network traffic and investigating PCAP and PCAPNG files.

It fits the **Packet capture and analysis** section because it supports live libpcap capture, capture-file inspection, protocol decoding, and session-oriented analysis.

- AGPL-3.0 licensed
- Actively maintained
- Native macOS application
- Canonical source repository used as the link