### PR TITLE
Add Rockxy to Packet capture and analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ by James Forshaw.
 * [Malware-Traffic-Analysis.net](https://malware-traffic-analysis.net/) - A large collection of malicious PCAP files that can be used to practice packet capture skills.
 * [Publicly Available PCAP files](https://www.netresec.com/?page=PcapFiles) - A list of publicly available PCAP files for additional training.
 * [PWRU (Packet, where are you?)](https://github.com/cilium/pwru) - eBPF-based Linux kernel networking debugger.
+* [Rockxy](https://github.com/RockxyApp/Rockxy) - An open source native macOS HTTP debugging proxy for inspecting HTTPS, API, WebSocket, and GraphQL traffic.
 
 ### Network simulators and emulators
 


### PR DESCRIPTION
Adds [Rockxy](https://github.com/RockxyApp/Rockxy), an open source native macOS HTTP debugging proxy for inspecting HTTPS, API, WebSocket, and GraphQL traffic.

It fits the **Packet capture and analysis** section because it captures and inspects application-layer network traffic for debugging, with HTTPS interception, protocol inspection, and response mocking.

- AGPL-3.0 licensed source
- Actively maintained
- Native macOS application
- Canonical source repository used as the link