### PR TITLE
Add Shieldxy to Firewalls and switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ by James Forshaw.
 * [pfSense](https://www.pfsense.org/) - An open source firewall/router computer software distribution based on FreeBSD.
 * [OPNsense](https://opnsense.org/) - OPNsense is an open source, easy-to-use, and easy-to-build FreeBSD based firewall and routing platform.
 * [Open vSwitch](https://www.openvswitch.org/) - Open vSwitch is a production quality, multilayer virtual switch licensed under the open source Apache 2.0 license.
+* [Shieldxy](https://github.com/RockxyApp/Shieldxy) - An open source, auditable application firewall and connection monitor for macOS.
 
 ### Remote access and sharing tools
 


### PR DESCRIPTION
Adds [Shieldxy](https://github.com/RockxyApp/Shieldxy), an open source, auditable application firewall and connection monitor for macOS.

It fits the **Firewalls and switches** section because it provides application-aware connection monitoring and explicit application and domain firewall controls through the macOS Network Extension framework.

- AGPL-3.0 licensed
- Actively maintained
- Native macOS application
- Canonical source repository used as the link